### PR TITLE
Add missing environment variables to Cloud Run deployment script

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -29,6 +29,8 @@ $CredsJson = $CredsJson -replace '\r\n', '' -replace '\n', '' -replace '\s+', ' 
 
 Write-Host "Project ID: $GCP_PROJECT_ID"
 Write-Host "Bot Token: $TELEGRAM_BOT_TOKEN"
+Write-Host "Service URL: $SERVICE_URL"
+Write-Host "GAS WebApp URL: $GAS_WEBAPP_URL"
 Write-Host "Building image..."
 
 # 4. Submit Build (Build and Push)
@@ -48,6 +50,6 @@ gcloud run deploy focustimer-bot `
     --region asia-east1 `
     --platform managed `
     --allow-unauthenticated `
-    --set-env-vars NODE_ENV="production", TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN", GOOGLE_CREDENTIALS_JSON="$CredsJson", GOOGLE_CALENDAR_ID="$GOOGLE_CALENDAR_ID"
+    --set-env-vars NODE_ENV="production",TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN",SERVICE_URL="$SERVICE_URL",GAS_WEBAPP_URL="$GAS_WEBAPP_URL",GAS_API_KEY="$GAS_API_KEY",GOOGLE_CREDENTIALS_JSON="$CredsJson",GOOGLE_CALENDAR_ID="$GOOGLE_CALENDAR_ID"
 
 Write-Host "Deployment Complete!"


### PR DESCRIPTION
The `deploy.ps1` script was missing critical environment variables (`SERVICE_URL`, `GAS_WEBAPP_URL`, `GAS_API_KEY`) when deploying to Google Cloud Run. This caused the bot to skip webhook registration and failed to connect to the GAS bridge. This PR adds these variables to the deployment command and adds log output for better visibility during deployment.

---
*PR created automatically by Jules for task [6633516982297383011](https://jules.google.com/task/6633516982297383011) started by @end8cl01g*