### PR TITLE
Fix Cannot GET / error by including public folder in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN npm ci --only=production
 
 # Copy built artifacts from the builder stage
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/public ./public
 
 # Expose the port (Cloud Run sets PORT env var, defaults to 8080)
 EXPOSE 8080

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import express from 'express';
 import bot, { calendarManager } from './bot';
 import * as dotenv from 'dotenv';
@@ -5,7 +6,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 const app = express();
-app.use(express.static('public'));
+app.use(express.static(path.join(__dirname, '../public')));
 
 // Health check
 app.get('/health', (_req, res) => {


### PR DESCRIPTION
The "Cannot GET /" error was caused by the public directory not being copied to the production stage of the Docker image. I fixed this in the Dockerfile and also updated the Express static middleware to use an absolute path for better reliability.

---
*PR created automatically by Jules for task [15487065881263069493](https://jules.google.com/task/15487065881263069493) started by @end8cl01g*