### PR TITLE
Fix blank page on loading error in Mini App

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,11 +88,18 @@
         async function fetchTasks() {
             try {
                 const response = await fetch('/api/tasks');
+                if (!response.ok) {
+                    const errorData = await response.json().catch(() => ({}));
+                    const msg = errorData.details ? `${errorData.error} (${errorData.details})` : (errorData.error || `伺服器錯誤: ${response.status}`);
+                    throw new Error(msg);
+                }
                 tasks = await response.json();
                 renderTasks();
             } catch (error) {
-                console.error(error);
-                document.getElementById('loading').innerText = '載入失敗，請稍後再試。';
+                console.error('fetchTasks error:', error);
+                const loading = document.getElementById('loading');
+                loading.innerText = '載入失敗：' + error.message;
+                loading.style.display = 'block';
             }
         }
 
@@ -138,6 +145,14 @@
         function renderTasks() {
             const list = document.getElementById('task-list');
             const loading = document.getElementById('loading');
+
+            if (!Array.isArray(tasks)) {
+                console.error('Tasks is not an array:', tasks);
+                loading.innerText = '載入失敗：資料格式錯誤';
+                loading.style.display = 'block';
+                return;
+            }
+
             loading.style.display = 'none';
 
             if (tasks.length === 0) {

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -70,6 +70,11 @@ export class CalendarManager {
             timeMax: end.toISOString(),
         });
 
+        if (!result || !Array.isArray(result.events)) {
+            console.error('GAS listEvents returned invalid data:', result);
+            return [];
+        }
+
         return result.events.map(ev => ({
             id: ev.id,
             title: ev.title,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,10 @@ app.get('/api/tasks', async (_req, res) => {
         res.json(events);
     } catch (error) {
         console.error('API /api/tasks error:', error);
-        res.status(500).json({ error: 'Failed to fetch tasks' });
+        res.status(500).json({
+            error: 'Failed to fetch tasks',
+            details: error instanceof Error ? error.message : String(error)
+        });
     }
 });
 


### PR DESCRIPTION
The issue where the Mini App would show a blank page after the "Loading" state was caused by unhandled errors during data fetching and processing. If the API returned a non-OK status or an unexpected data format (e.g., an error object instead of an array), the frontend would crash or hide the loading indicator without displaying an error message.

This PR fixes the issue by:
1. Improving the frontend `fetchTasks` function to check for `response.ok` and handle both network and server-side errors.
2. Updating `renderTasks` to validate that the received tasks are indeed an array before attempting to map over them.
3. Ensuring the loading element is used to display descriptive error messages when things go wrong, and that it remains visible.
4. Enhancing the backend API to provide more context in error responses.
5. Adding defensive checks in the `CalendarManager` to handle unexpected data from the Google Apps Script bridge.

Verified with a Playwright screenshot showing the error message being correctly displayed when the API fails.

Fixes #13

---
*PR created automatically by Jules for task [17024330431844739320](https://jules.google.com/task/17024330431844739320) started by @end8cl01g*